### PR TITLE
Organized stuff and updated for relevant version of rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "comptime"
 version = "0.1.1"
 authors = ["Nick Hynes <nhynes@nhynes.com>"]
-edition = "2018"
+edition = "2021"
 description = "Compile-time code execution (i.e. lightweight proc-macro)"
 readme = "README.md"
 repository = "https://github.com/nhynes/comptime-rs"
@@ -15,3 +15,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
+
+[dev-dependencies]
+rand = "0.7"
+chrono = "0.4"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "comptime-tests"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Nick Hynes <nhynes@nhynes.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 comptime = { path = "../" }

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene)]
 
 fn main() {
     println!(concat!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,7 @@
 //!
 //! ### Example
 //!
-//! ```
-//! #![feature(proc_macro_hygiene)]
+//! ``` compile_fail
 //! fn main() {
 //!     println!(concat!(
 //!         "The program was compiled on ",
@@ -29,6 +28,9 @@
 //!
 //! Also, `comptime!` requires you to run `cargo build` at least once before `cargo (clippy|check)`
 //! will work since `comptime!` does not compile dependencies.
+//!
+//! Finally, using this macro in doctests may fail with strange errors for no good reason. This is
+//! because output directory detection is imperfect and sometimes breaks. You have been warned.
 
 extern crate proc_macro;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene)]
 #![cfg(test)]
 
 #[macro_use]


### PR DESCRIPTION
I've found this gem by accident and it seems to work correctly on stable rust. I suppose it would not hurt to push a relevant version out. 

While organizing the tests etc I've noticed that the detection of output directory to cache artifacts is "imperfect" to say the least (which breaks e.g. cargo test when it is called for "parent" crate), maybe this can be improved? I'm just not sure what would be a better way, but parsing the compiler argument seems to be fragile.